### PR TITLE
MenuPlan 서비스 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ TODO (우선순위 정렬)
 		...
     ]
 - [X] MenuPlanRequestDto 만들기
-- [ ] 요청받은 데이터 저장 기능 만들기 (service, repository)
+- [X] 요청받은 MenuPlan 저장 기능 만들기 (service, repository)
+- [ ] MenuPlan 저장 기능 의존성 과다 아닌지 확인할 것
+- [ ] 요청받은 MenuPlan 저장 기능 중 Menu가 없는 경우 예외 처리하기
+- [ ] 요청받은 MenuPlan 저장 기능 중 WorkDay가 없는 경우 예외 처리하기
 - [ ] GET /workDay/{20190930} 응답 기능 만들기
     {	
         "day": "월",

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
@@ -1,14 +1,66 @@
 package com.poppo.dallab.cafeteria.applications;
 
-import com.poppo.dallab.cafeteria.domain.Menu;
+import com.poppo.dallab.cafeteria.domain.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Service
 public class MenuPlanService {
 
-    public void addBulkMenu(String date, List<Menu> menus) {
+    MenuPlanRepository menuPlanRepository;
+
+    WorkDayRepository workDayRepository;
+
+    MenuRepository menuRepository;
+
+    @Autowired
+    public MenuPlanService(
+            MenuPlanRepository menuPlanRepository,
+            WorkDayRepository workDayRepository,
+            MenuRepository menuRepository
+    ) {
+        this.menuPlanRepository = menuPlanRepository;
+        this.workDayRepository = workDayRepository;
+        this.menuRepository = menuRepository;
+    }
+
+    public void addBulkMenu(String workDay, List<Menu> menus) {
+
+        // 테스트 생략!!!
+        // 아래꺼 잘 돌아가니까 잘돌겠지!!!
+        for (Menu menu : menus) {
+            addMenu(workDay, menu);
+        }
+
+    }
+
+    public MenuPlan addMenu(String workDay, Menu menu) {
+
+        Long workDayId = getWorkDayId(workDay);
+        Long menuId = menuRepository.findByName(menu.getName()).getId();
+
+        MenuPlan menuPlan = MenuPlan.builder()
+                .menuId(menuId)
+                .workDayId(workDayId)
+                .build();
+
+        return menuPlanRepository.save(menuPlan);
+
+    }
+
+    public Long getWorkDayId(String workDay) {
+
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate date = LocalDate.parse(workDay, dateTimeFormatter);
+
+        WorkDay foundWorkDay = workDayRepository.findByDate(date);
+
+        return foundWorkDay.getId();
+
     }
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/MenuRepository.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/MenuRepository.java
@@ -3,4 +3,7 @@ package com.poppo.dallab.cafeteria.domain;
 import org.springframework.data.repository.CrudRepository;
 
 public interface MenuRepository extends CrudRepository<Menu, Long> {
+
+    Menu findByName(String name);
+
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
@@ -2,5 +2,10 @@ package com.poppo.dallab.cafeteria.domain;
 
 import org.springframework.data.repository.CrudRepository;
 
+import java.time.LocalDate;
+
 public interface WorkDayRepository extends CrudRepository<WorkDay, Long> {
+
+    WorkDay findByDate(LocalDate date);
+
 }

--- a/cafeteria-manage-api/src/main/resources/application.yml
+++ b/cafeteria-manage-api/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:~/data/selfdemo
+    url: jdbc:h2:~/data/cafeteria
   jpa:
     hibernate:
       ddl-auto: update

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/MenuPlanServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/MenuPlanServiceTests.java
@@ -1,0 +1,96 @@
+package com.poppo.dallab.cafeteria.applications;
+
+import com.poppo.dallab.cafeteria.domain.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+public class MenuPlanServiceTests {
+
+    MenuPlanService menuPlanService;
+
+    @MockBean
+    MenuPlanRepository menuPlanRepository;
+
+    @MockBean
+    WorkDayRepository workDayRepository;
+
+    @MockBean
+    MenuRepository menuRepository;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        menuPlanService = new MenuPlanService(menuPlanRepository, workDayRepository, menuRepository);
+    }
+
+    // TODO: 의존성이 너무 덕지덕지 붙고 있음 리팩토링 필요
+    @Test
+    public void addMenuPlanWithMenuAndWorkDay() {
+
+        String workDay = "2019-10-01";
+
+        Menu mockMenu = Menu.builder()
+                .id(2L)
+                .name("제육볶음")
+                .build();
+
+        MenuPlan mockMenuPlan = MenuPlan.builder()
+                .id(3L)
+                .menuId(2L)
+                .workDayId(1L)
+                .build();
+
+        // MenuPlanRepository 의존성
+        given(menuPlanRepository.save(any())).willReturn(mockMenuPlan);
+
+        // WorkDayRepository 의존성
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate date = LocalDate.parse(workDay, dateTimeFormatter);
+        WorkDay mockWorkDay = WorkDay.builder().id(3L).build();
+        given(workDayRepository.findByDate(date)).willReturn(mockWorkDay);
+
+        // MenuRepository 의존성
+        given(menuRepository.findByName("제육볶음")).willReturn(mockMenu);
+
+        MenuPlan menuPlan = menuPlanService.addMenu(workDay, mockMenu);
+        assertThat(menuPlan.getId()).isEqualTo(3L);
+        assertThat(menuPlan.getMenuId()).isEqualTo(2L);
+        assertThat(menuPlan.getWorkDayId()).isEqualTo(1L);
+
+        // TODO: 정확한 타입이 들어가는지 확인하는 로직 만들 것
+        verify(menuPlanRepository).save(any());
+
+    }
+
+    @Test
+    public void getWorkDayId() {
+
+        String workDay = "2019-10-01";
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        LocalDate date = LocalDate.parse(workDay, dateTimeFormatter);
+
+        WorkDay mockWorkDay = WorkDay.builder().id(3L).build();
+
+        given(workDayRepository.findByDate(date)).willReturn(mockWorkDay);
+
+        Long workDayId = menuPlanService.getWorkDayId(workDay);
+
+        assertThat(workDayId).isEqualTo(3L);
+
+    }
+
+}

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
@@ -31,7 +31,7 @@ public class MenuPlanControllerTests {
     @Test
     public void bulkCreate() throws Exception {
 
-        mvc.perform(post("/workDay/20190930/menuPlans")
+        mvc.perform(post("/workDay/2019-09-30/menuPlans")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("[\n" +
                         "        {\n" +
@@ -41,11 +41,11 @@ public class MenuPlanControllerTests {
                         "            \"name\": \"닭갈비\"\n" +
                         "        }\n" +
                         "    ]"))
-                .andExpect(header().stringValues("Location", "/workDay/20190930/menuPlans"))
+                .andExpect(header().stringValues("Location", "/workDay/2019-09-30/menuPlans"))
                 .andExpect(status().isCreated());
 
         // TODO: anyList 앞에 꼭 Mockito 붙어야 하는지 확인할 것
-        verify(menuPlanService).addBulkMenu(eq("20190930"), Mockito.<Menu>anyList());
+        verify(menuPlanService).addBulkMenu(eq("2019-09-30"), Mockito.<Menu>anyList());
 
     }
 

--- a/httpTest/MenuPlanTest.http
+++ b/httpTest/MenuPlanTest.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/workDay/2019-09-30/menuPlans
+Content-Type: application/json
+
+[
+  {
+    "name": "제육볶음"
+  }
+]
+
+###


### PR DESCRIPTION
- README에 MenuPlanService 예외 관련 TODO 리스트 추가
- Menu, WorkDay 모두 기존에 있는 해피패스 구현
- MenuPlanService 의존성 너무 많지 않은지 점검 필요
- MenuPlanService에서 바로 다른 도메인 Repository 의존성 갖는 게 맞는지 다시 고민
- 의존성 완료되면 Menu 없는 경우 구현할 것