### PR TITLE
Merge#13 refactoring

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/Mapper.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/Mapper.java
@@ -3,13 +3,9 @@ package com.poppo.dallab.cafeteria.adapters;
 import com.poppo.dallab.cafeteria.domain.Menu;
 import com.poppo.dallab.cafeteria.interfaces.MenuPlanRequestDto;
 
-import java.util.List;
-
 public interface Mapper {
 
     // TODO: 향후 DTO 타입이 많이 추가되면 제네릭 전환 고려??
     Menu menuMapping(MenuPlanRequestDto source);
-
-    List<Menu> manyMenuMapping(List<MenuPlanRequestDto> sources);
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/Mapper.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/Mapper.java
@@ -1,11 +1,7 @@
 package com.poppo.dallab.cafeteria.adapters;
 
-import com.poppo.dallab.cafeteria.domain.Menu;
-import com.poppo.dallab.cafeteria.interfaces.MenuPlanRequestDto;
-
 public interface Mapper {
 
-    // TODO: 향후 DTO 타입이 많이 추가되면 제네릭 전환 고려??
-    Menu menuMapping(MenuPlanRequestDto source);
+    <D> D mapping(Object source, D destination);
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapter.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapter.java
@@ -1,13 +1,10 @@
 package com.poppo.dallab.cafeteria.adapters;
 
-import com.poppo.dallab.cafeteria.domain.Menu;
-import com.poppo.dallab.cafeteria.interfaces.MenuPlanRequestDto;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import java.lang.reflect.Type;
 
 @Component
 public class ModelMapperAdapter implements Mapper {
@@ -20,10 +17,8 @@ public class ModelMapperAdapter implements Mapper {
     }
 
     @Override
-    public Menu menuMapping(MenuPlanRequestDto source) {
+    public <D> D mapping(Object source, D destination) {
 
-        Menu menu = adaptee.map(source, Menu.class);
-
-        return menu;
+        return adaptee.map(source, (Type) destination.getClass());
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapter.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapter.java
@@ -26,12 +26,4 @@ public class ModelMapperAdapter implements Mapper {
 
         return menu;
     }
-
-    @Override
-    public List<Menu> manyMenuMapping(List<MenuPlanRequestDto> sources) {
-
-        return sources.stream()
-                .map(this::menuMapping)
-                .collect(Collectors.toList());
-    }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 public class MenuPlanController {
@@ -35,7 +36,9 @@ public class MenuPlanController {
 
         String url = "/workDay/"+ date +"/menuPlans";
 
-        List<Menu> menus = mapper.manyMenuMapping(menuPlanRequestDtos);
+        List<Menu> menus = menuPlanRequestDtos.stream()
+                .map(menuPlanRequestDto -> mapper.menuMapping(menuPlanRequestDto))
+                .collect(Collectors.toList());
 
         menuPlanService.addBulkMenu(date, menus);
 

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
@@ -37,7 +37,7 @@ public class MenuPlanController {
         String url = "/workDay/"+ date +"/menuPlans";
 
         List<Menu> menus = menuPlanRequestDtos.stream()
-                .map(menuPlanRequestDto -> mapper.menuMapping(menuPlanRequestDto))
+                .map(menuPlanRequestDto -> mapper.mapping(menuPlanRequestDto, new Menu()))
                 .collect(Collectors.toList());
 
         menuPlanService.addBulkMenu(date, menus);

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
@@ -9,8 +9,11 @@ import org.modelmapper.ModelMapper;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.lang.reflect.Type;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 @RunWith(SpringRunner.class)
@@ -32,9 +35,10 @@ public class ModelMapperAdapterTests {
         Menu menu = Menu.builder().name("제육볶음").build();
         MenuPlanRequestDto mockMenuPlanRequestDto = MenuPlanRequestDto.builder().name("제육볶음").build();
 
-        given(modelMapper.map(any(), any())).willReturn(menu);
+        // TODO: mapping의 두번째 파라미터를 바꾸던가 테스트 편하게 할 방법을 찾던가 할 것
+        given(modelMapper.map(any(), eq((Type) Menu.class))).willReturn(menu);
 
-        Menu result = modelMapperAdapter.menuMapping(mockMenuPlanRequestDto);
+        Menu result = modelMapperAdapter.mapping(mockMenuPlanRequestDto, new Menu());
 
         assertThat(result.getName()).isEqualTo("제육볶음");
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
@@ -9,9 +9,6 @@ import org.modelmapper.ModelMapper;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import java.util.Arrays;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -40,21 +37,6 @@ public class ModelMapperAdapterTests {
         Menu result = modelMapperAdapter.menuMapping(mockMenuPlanRequestDto);
 
         assertThat(result.getName()).isEqualTo("제육볶음");
-
-    }
-
-    @Test
-    public void manyMenuMapperTest() {
-
-        List<MenuPlanRequestDto> mockMenuPlanRequestDtos = Arrays.asList(
-                MenuPlanRequestDto.builder().name("제육볶음").build()
-        );
-
-        given(modelMapper.map(any(), any())).willReturn(Menu.builder().name("제육볶음").build());
-
-        List<Menu> menus = modelMapperAdapter.manyMenuMapping(mockMenuPlanRequestDtos);
-
-        assertThat(menus.get(0).getName()).isEqualTo("제육볶음");
 
     }
 


### PR DESCRIPTION
1. MenuPlanRequestDtoController 수정
- Menu Collection 매핑 과정의 과다한 추상화 제거
- 기존: Adapter의 Collection 매핑 구현 및 이용
- 변경후: Adapter의 Member 매핑 이용 + 컨트롤러에 로직 드러나도록 변경

2. ModelMapperAdapter 수정
- Menu oneMenuMap(MenuPlanRequestDto) -> <D> D mapping(Object source, D destination)
- 변경 전: Mapper 인터페이스에 지나치게 구체적인 타입이 명시되어 있었음
- 변경 후: 제네릭을 활용하여 다양한 타입을 받을 수 있도록 변경
- 추가 고려 사항: 제네릭 관련 테스트가 너무 구체적으로 명시해야 되게 됨(ModelMapperAdapterTests)
- 필요 사항: 제네릭, 리플렉션에 대해 좀 더 공부하고 다시 도전할 것..