### PR TITLE
WorkDay POST API 구현

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -37,5 +38,20 @@ public class WorkDayService {
 //        thisWeek.forEach(weekDay -> workDays.add(workDayRepository.findByDate(weekDay)));
 
         return workDays;
+    }
+
+    public List<WorkDay> bulkCreate(Integer month) {
+
+        // TODO: LocalDate 여러개 생성하는 걸 DateTimeUtil이 할지 WorkDay Domain이 할지 고민해볼 것
+        // TODO: 아니 그 전에 이렇게 한방에 빡 하고 만드는 게 옳은일인지부터 고민해봐야 되지 않을까...
+
+        List<LocalDate> daysOfMonth = dateTimeUtils.getLocalDatesByMonth(month);
+
+        return daysOfMonth.stream().map(dayOfMonth ->
+                    workDayRepository.save(WorkDay.builder()
+                        .date(dayOfMonth)
+                        .day(dayOfMonth.getDayOfWeek().name())
+                        .build()))
+                .collect(Collectors.toList());
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanRequestDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanRequestDto.java
@@ -1,4 +1,4 @@
-package com.poppo.dallab.cafeteria.interfaces;
+package com.poppo.dallab.cafeteria.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanResponseDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanResponseDto.java
@@ -1,4 +1,4 @@
-package com.poppo.dallab.cafeteria.interfaces;
+package com.poppo.dallab.cafeteria.dto;
 
 import com.poppo.dallab.cafeteria.domain.Menu;
 import lombok.AllArgsConstructor;

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuRequestDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuRequestDto.java
@@ -1,4 +1,4 @@
-package com.poppo.dallab.cafeteria.interfaces;
+package com.poppo.dallab.cafeteria.dto;
 
 import lombok.Data;
 

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuResponseDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuResponseDto.java
@@ -1,4 +1,4 @@
-package com.poppo.dallab.cafeteria.interfaces;
+package com.poppo.dallab.cafeteria.dto;
 
 import lombok.Builder;
 import lombok.Data;

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/WorkDayRequestDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/WorkDayRequestDto.java
@@ -1,0 +1,16 @@
+package com.poppo.dallab.cafeteria.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkDayRequestDto {
+
+    private Integer menuPlanMonth;
+
+}

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuController.java
@@ -2,6 +2,8 @@ package com.poppo.dallab.cafeteria.interfaces;
 
 import com.poppo.dallab.cafeteria.applications.MenuService;
 import com.poppo.dallab.cafeteria.domain.Menu;
+import com.poppo.dallab.cafeteria.dto.MenuRequestDto;
+import com.poppo.dallab.cafeteria.dto.MenuResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanController.java
@@ -6,6 +6,8 @@ import com.poppo.dallab.cafeteria.applications.MenuService;
 import com.poppo.dallab.cafeteria.applications.WorkDayService;
 import com.poppo.dallab.cafeteria.domain.Menu;
 import com.poppo.dallab.cafeteria.domain.WorkDay;
+import com.poppo.dallab.cafeteria.dto.MenuPlanRequestDto;
+import com.poppo.dallab.cafeteria.dto.MenuPlanResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
@@ -1,0 +1,34 @@
+package com.poppo.dallab.cafeteria.interfaces;
+
+import com.poppo.dallab.cafeteria.applications.WorkDayService;
+import com.poppo.dallab.cafeteria.domain.WorkDay;
+import com.poppo.dallab.cafeteria.dto.WorkDayRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class WorkDayController {
+
+    private final WorkDayService workDayService;
+
+    @PostMapping("/workDay")
+    public ResponseEntity startMonth(
+            @RequestBody WorkDayRequestDto requestDto
+    ) throws URISyntaxException {
+
+        List<WorkDay> workDays = workDayService.bulkCreate(requestDto.getMenuPlanMonth());
+        String url = "/workDay";
+
+        return ResponseEntity.created(new URI(url)).body("Created " + workDays.size() + " days");
+
+    }
+
+}

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
@@ -3,6 +3,7 @@ package com.poppo.dallab.cafeteria.utils;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalField;
 import java.time.temporal.WeekFields;
@@ -32,4 +33,23 @@ public class DateTimeUtils {
         return localDates;
     }
 
+    public List<LocalDate> getLocalDatesByMonth(Integer requestMonth) {
+
+        Integer thisYear = LocalDate.now().getYear();
+        Integer dayLength = this.getDayLengthOfMonth(thisYear, requestMonth);
+
+        List<LocalDate> monthDays = new ArrayList<>();
+        for (int i = 1; i < dayLength + 1; i ++) {
+            monthDays.add(LocalDate.of(thisYear, requestMonth, i));
+        }
+
+        return monthDays;
+    }
+
+    public Integer getDayLengthOfMonth(Integer year, Integer month) {
+
+        YearMonth yearMonth = YearMonth.of(year, month);
+
+        return yearMonth.lengthOfMonth();
+    }
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/adapters/ModelMapperAdapterTests.java
@@ -1,7 +1,7 @@
 package com.poppo.dallab.cafeteria.adapters;
 
 import com.poppo.dallab.cafeteria.domain.Menu;
-import com.poppo.dallab.cafeteria.interfaces.MenuPlanRequestDto;
+import com.poppo.dallab.cafeteria.dto.MenuPlanRequestDto;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -79,4 +79,20 @@ public class WorkDayServiceTests {
 
     }
 
+    @Test
+    public void 한방에_해당월_날짜_전부_만들기() {
+
+        List<LocalDate> mockLocalDates = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            mockLocalDates.add(LocalDate.now());
+        }
+        given(dateTimeUtils.getLocalDatesByMonth(11))
+                .willReturn(mockLocalDates);
+
+        List<WorkDay> workDays = workDayService.bulkCreate(11);
+
+        assertThat(workDays.size()).isEqualTo(30);
+
+    }
+
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayTests.java
@@ -1,0 +1,5 @@
+package com.poppo.dallab.cafeteria.domain;
+
+public class WorkDayTests {
+
+}

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
@@ -1,0 +1,52 @@
+package com.poppo.dallab.cafeteria.interfaces;
+
+import com.poppo.dallab.cafeteria.applications.WorkDayService;
+import com.poppo.dallab.cafeteria.domain.WorkDay;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(WorkDayController.class)
+public class WorkDayControllerTests {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private WorkDayService workDayService;
+
+    @Test
+    public void 새로운_달의_시작_요청() throws Exception {
+
+        List<WorkDay> mockWorkDays = new ArrayList<>();
+        for(int i = 0; i < 30; i++) {
+            mockWorkDays.add(WorkDay.builder().build());
+        }
+
+        given(workDayService.bulkCreate(11)).willReturn(mockWorkDays);
+
+        mvc.perform(post("/workDay")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"menuPlanMonth\": 11}"))
+                .andExpect(status().isCreated())
+                .andExpect(content().string(containsString("30")))
+        ;
+
+    }
+
+}

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
@@ -1,22 +1,23 @@
 package com.poppo.dallab.cafeteria.utils;
 
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
 public class DateTimeUtilsTests {
 
     @Autowired
-    DateTimeUtils dateTimeUtils;
+    private DateTimeUtils dateTimeUtils;
+
+    @Before
+    public void setup() {
+        dateTimeUtils = new DateTimeUtils();
+    }
 
     @Test
     public void stringDateToLocalDate() {
@@ -55,6 +56,40 @@ public class DateTimeUtilsTests {
         assertThat(localDates.get(4).getDayOfWeek().name()).isEqualTo("FRIDAY");
         assertThat(localDates.get(4).toString()).isEqualTo("2019-10-11");
 
+    }
+
+    @Test
+    public void 월로부터_날짜_여러개_받기() {
+        List<LocalDate> monthDays = dateTimeUtils.getLocalDatesByMonth(11);
+
+        assertThat(monthDays.size()).isEqualTo(30);
+        assertThat(monthDays.get(0).getDayOfMonth()).isEqualTo(1);
+        assertThat(monthDays.get(29).getDayOfMonth()).isEqualTo(30);
+    }
+
+    @Test
+    public void 해당년도_월의_날짜수_받기() {
+
+        Integer monthDaySize = dateTimeUtils.getDayLengthOfMonth(2019, 11);
+
+        assertThat(monthDaySize).isEqualTo(30);
+    }
+
+    @Test
+    public void 윤달이_아닌_2월_날짜수_받기() {
+
+        Integer monthDaySize = dateTimeUtils.getDayLengthOfMonth(2019, 2);
+
+        assertThat(monthDaySize).isEqualTo(28);
+
+    }
+
+    @Test
+    public void 윤달인_2월_날짜수_받기() {
+
+        Integer monthDaySize = dateTimeUtils.getDayLengthOfMonth(2016, 2);
+
+        assertThat(monthDaySize).isEqualTo(29);
     }
 
 }

--- a/httpTest/WorkDayTest.http
+++ b/httpTest/WorkDayTest.http
@@ -1,0 +1,8 @@
+POST http://localhost:8080/workDay
+Content-Type: application/json
+
+{
+  "menuPlanMonth": 11
+}
+
+###


### PR DESCRIPTION
- 요청받은 월의 WorkDay를 한꺼번에 생성하도록 구현
- 과연 이렇게 이상하게 생성하는 게 맞는지 고민..
- WorkDay 생성의 책임도 도메인, DateTimeUtil에서 어디가 가져가야 될지 고민
- 현재 프론트와 연동 안되는 상태 -> 다음 업데이트 때 고칠 것