### PR TITLE
식단 입력 페이지 디버깅

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
@@ -5,6 +5,7 @@ import com.poppo.dallab.cafeteria.domain.WorkDay;
 import com.poppo.dallab.cafeteria.dto.WorkDayRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,6 +15,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
+@CrossOrigin
 @RequiredArgsConstructor
 public class WorkDayController {
 

--- a/cafeteria-manage-web/src/api/index.js
+++ b/cafeteria-manage-web/src/api/index.js
@@ -28,6 +28,6 @@ export const menu = {
 
 export const menuPlan = {
   create(menuPlanMonth) {
-    return request('post', 'menuPlans', { menuPlanMonth })
+    return request('post', '/workDay', { menuPlanMonth })
   }
 }


### PR DESCRIPTION
- 프론트엔드에서 새 식단 요청 이벤트 발생시 API 콜 발생하지 않는 오류 수정
- 오류 원인: 오타 + API 주소 잘못됨
- 기능을 구현하기 전에 시나리오를 좀 더 견고하게 짜고, 명세서를 남겨서 참고할 필요가 있을 것 같음
- 이후 윤석님, 아샬님 피드백 우선 적용할 것