### PR TITLE
Pr#25 comment apply

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -47,11 +47,15 @@ public class WorkDayService {
 
         List<LocalDate> daysOfMonth = dateTimeUtils.getLocalDatesByMonth(month);
 
-        return daysOfMonth.stream().map(dayOfMonth ->
-                    workDayRepository.save(WorkDay.builder()
+        List<WorkDay> workDays = daysOfMonth.stream()
+                .map(dayOfMonth -> WorkDay.builder()
                         .date(dayOfMonth)
                         .day(dayOfMonth.getDayOfWeek().name())
-                        .build()))
+                        .build())
                 .collect(Collectors.toList());
+
+        workDayRepository.saveAll(workDays);
+
+        return workDays;
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
@@ -10,6 +10,8 @@ import java.time.temporal.WeekFields;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Component
 public class DateTimeUtils {
@@ -38,12 +40,14 @@ public class DateTimeUtils {
         Integer thisYear = LocalDate.now().getYear();
         Integer dayLength = this.getDayLengthOfMonth(thisYear, requestMonth);
 
-        List<LocalDate> monthDays = new ArrayList<>();
-        for (int i = 1; i < dayLength + 1; i ++) {
-            monthDays.add(LocalDate.of(thisYear, requestMonth, i));
-        }
+//        List<LocalDate> monthDays = new ArrayList<>();
+//        for (int i = 1; i < dayLength + 1; i ++) {
+//            monthDays.add(LocalDate.of(thisYear, requestMonth, i));
+//        }
 
-        return monthDays;
+        return IntStream.range(1, dayLength)
+                .mapToObj(day -> LocalDate.of(thisYear, requestMonth, day))
+                .collect(Collectors.toList());
     }
 
     public Integer getDayLengthOfMonth(Integer year, Integer month) {

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
@@ -45,7 +45,8 @@ public class DateTimeUtils {
 //            monthDays.add(LocalDate.of(thisYear, requestMonth, i));
 //        }
 
-        return IntStream.range(1, dayLength)
+        // range의 끝 수가 빠지는 듯
+        return IntStream.range(1, dayLength + 1)
                 .mapToObj(day -> LocalDate.of(thisYear, requestMonth, day))
                 .collect(Collectors.toList());
     }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -91,7 +92,8 @@ public class WorkDayServiceTests {
 
         List<WorkDay> workDays = workDayService.bulkCreate(11);
 
-        assertThat(workDays.size()).isEqualTo(30);
+        verify(workDayRepository).saveAll(any());
+        assertThat(workDays).isEqualTo(30);
 
     }
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -83,10 +85,10 @@ public class WorkDayServiceTests {
     @Test
     public void 한방에_해당월_날짜_전부_만들기() {
 
-        List<LocalDate> mockLocalDates = new ArrayList<>();
-        for (int i = 0; i < 30; i++) {
-            mockLocalDates.add(LocalDate.now());
-        }
+        List<LocalDate> mockLocalDates = Stream.generate(LocalDate::now)
+                .limit(30)
+                .collect(Collectors.toList());
+
         given(dateTimeUtils.getLocalDatesByMonth(11))
                 .willReturn(mockLocalDates);
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -93,7 +93,7 @@ public class WorkDayServiceTests {
         List<WorkDay> workDays = workDayService.bulkCreate(11);
 
         verify(workDayRepository).saveAll(any());
-        assertThat(workDays).isEqualTo(30);
+        assertThat(workDays).hasSize(30);
 
     }
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
@@ -11,8 +11,9 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.BDDMockito.given;
@@ -33,10 +34,9 @@ public class WorkDayControllerTests {
     @Test
     public void 새로운_달의_시작_요청() throws Exception {
 
-        List<WorkDay> mockWorkDays = new ArrayList<>();
-        for(int i = 0; i < 30; i++) {
-            mockWorkDays.add(WorkDay.builder().build());
-        }
+        List<WorkDay> mockWorkDays = Stream.generate(WorkDay::new)
+                .limit(30)
+                .collect(Collectors.toList());
 
         given(workDayService.bulkCreate(11)).willReturn(mockWorkDays);
 


### PR DESCRIPTION
1. WorkDayService 수정
- 윤석님, 아샬님 조언대로 map의 줄바꿈을 통해 다른 가독성 높이기
- 아샬님 조언대로 stream 안에서 save 로직을 분리
- 분리된 save 로직을 repository의savaAll로 변환하여 효율성 높이기

2. WorkDayService bulkCreate 테스트 수정
- 콜렉션의 수량 평가 변경(기존: size() + 단순 수량 비교 -> 변경후: .hasSize()활용)
- 반복문 형태 변경(기존: for문 -> 변경후: stream)

3. DateTimeUtil 수정
- for문을 통한 workDay 생성을 stream으로 변경(IntStream 활용)

4. Stream 적용
- WorkDayControllerTests에 적용

# 자바 Stream API 정독해볼 것