### PR TITLE
Get work month list

### DIFF
--- a/cafeteria-acceptance-test/MenuPlan_test.js
+++ b/cafeteria-acceptance-test/MenuPlan_test.js
@@ -10,9 +10,9 @@ Scenario('식단 입력 테스트(11월)', (I) => {
     I.amOnPage('http://localhost:3333/menuPlans');
     I.see('새 식단 추가')
     I.click('새 식단 추가');
-    I.fillField('month', '10');
+    I.fillField('workMonth', '10');
     I.click('식단 추가');
-    I.see('2019-11-01');
+    I.see('10월');
 });
 
 // Scenario('메뉴 삭제 테스트(제육볶음)', (I) => {

--- a/cafeteria-acceptance-test/MenuPlan_test.js
+++ b/cafeteria-acceptance-test/MenuPlan_test.js
@@ -6,7 +6,7 @@ Scenario('식단관리 관리 페이지 이동 확인', (I) => {
     I.see('식단 관리');
 });
 
-Scenario('식단 입력 테스트(11월)', (I) => {
+Scenario('식단 입력 테스트(10월)', (I) => {
     I.amOnPage('http://localhost:3333/menuPlans');
     I.see('새 식단 추가')
     I.click('새 식단 추가');

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -65,7 +65,7 @@ public class WorkDayService {
         List<Integer> workMonths = new ArrayList<>();
 
         IntStream.rangeClosed(1,12).forEach(month -> {
-            if(this.getSavedMonthSize(month) != 0) {
+            if(this.isThisMonthExists(month)) {
                 workMonths.add(month);
             }
         });
@@ -73,12 +73,12 @@ public class WorkDayService {
         return workMonths;
     }
 
-    protected Integer getSavedMonthSize(Integer month) {
+    protected Boolean isThisMonthExists(Integer month) {
 
         Integer thisYear = LocalDate.now().getYear();
         LocalDate startDate = LocalDate.of(thisYear, month, 1);
         LocalDate endDate = LocalDate.of(thisYear, month, dateTimeUtils.getDayLengthOfMonth(thisYear, month));
 
-        return workDayRepository.storedMonthSize(startDate, endDate);
+        return workDayRepository.existsByDateBetween(startDate,endDate);
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -65,11 +65,20 @@ public class WorkDayService {
         List<Integer> workMonths = new ArrayList<>();
 
         IntStream.rangeClosed(1,12).forEach(month -> {
-            if(dateTimeUtils.isThisMonthExists(month)) {
+            if(this.getSavedMonthSize(month) != 0) {
                 workMonths.add(month);
             }
         });
 
         return workMonths;
+    }
+
+    protected Integer getSavedMonthSize(Integer month) {
+
+        Integer thisYear = LocalDate.now().getYear();
+        LocalDate startDate = LocalDate.of(thisYear, month, 1);
+        LocalDate endDate = LocalDate.of(thisYear, month, dateTimeUtils.getDayLengthOfMonth(thisYear, month));
+
+        return workDayRepository.storedMonthSize(startDate, endDate);
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -11,6 +11,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @Transactional
@@ -57,5 +58,18 @@ public class WorkDayService {
         workDayRepository.saveAll(workDays);
 
         return workDays;
+    }
+
+    public List<Integer> getWorkMonths() {
+
+        List<Integer> workMonths = new ArrayList<>();
+
+        IntStream.rangeClosed(1,12).forEach(month -> {
+            if(dateTimeUtils.isThisMonthExists(month)) {
+                workMonths.add(month);
+            }
+        });
+
+        return workMonths;
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
@@ -1,14 +1,14 @@
 package com.poppo.dallab.cafeteria.domain;
 
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
-import java.util.List;
 
-public interface WorkDayRepository extends CrudRepository<WorkDay, Long> {
+public interface WorkDayRepository extends JpaRepository<WorkDay, Long> {
 
     WorkDay findByDate(LocalDate date);
 
-    List<WorkDay> findByDateBetween(LocalDate startDate, LocalDate endDate);
-
+    @Query("select count(w) from WorkDay w where w.date between ?1 and ?2")
+    Integer storedMonthSize(LocalDate startDate, LocalDate endDate);
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
@@ -1,7 +1,6 @@
 package com.poppo.dallab.cafeteria.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 
@@ -9,6 +8,5 @@ public interface WorkDayRepository extends JpaRepository<WorkDay, Long> {
 
     WorkDay findByDate(LocalDate date);
 
-    @Query("select count(w) from WorkDay w where w.date between ?1 and ?2")
-    Integer storedMonthSize(LocalDate startDate, LocalDate endDate);
+    Boolean existsByDateBetween(LocalDate startDate, LocalDate endDate);
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/domain/WorkDayRepository.java
@@ -3,9 +3,12 @@ package com.poppo.dallab.cafeteria.domain;
 import org.springframework.data.repository.CrudRepository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface WorkDayRepository extends CrudRepository<WorkDay, Long> {
 
     WorkDay findByDate(LocalDate date);
+
+    List<WorkDay> findByDateBetween(LocalDate startDate, LocalDate endDate);
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/WorkMonthResponseDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/WorkMonthResponseDto.java
@@ -1,0 +1,17 @@
+package com.poppo.dallab.cafeteria.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WorkMonthResponseDto {
+
+    private List<Integer> existedMonthList;
+}

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/interfaces/WorkDayController.java
@@ -3,12 +3,10 @@ package com.poppo.dallab.cafeteria.interfaces;
 import com.poppo.dallab.cafeteria.applications.WorkDayService;
 import com.poppo.dallab.cafeteria.domain.WorkDay;
 import com.poppo.dallab.cafeteria.dto.WorkDayRequestDto;
+import com.poppo.dallab.cafeteria.dto.WorkMonthResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -21,6 +19,17 @@ public class WorkDayController {
 
     private final WorkDayService workDayService;
 
+    @GetMapping("/workMonth")
+    public WorkMonthResponseDto getWorkMonthList() {
+
+        List<Integer> workMonthList = workDayService.getWorkMonths();
+        WorkMonthResponseDto workMonthResponseDto = WorkMonthResponseDto.builder()
+                .existedMonthList(workMonthList)
+                .build();
+
+        return workMonthResponseDto;
+    }
+
     @PostMapping("/workDay")
     public ResponseEntity startMonth(
             @RequestBody WorkDayRequestDto requestDto
@@ -30,7 +39,6 @@ public class WorkDayController {
         String url = "/workDay";
 
         return ResponseEntity.created(new URI(url)).body("Created " + workDays.size() + " days");
-
     }
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
@@ -1,6 +1,5 @@
 package com.poppo.dallab.cafeteria.utils;
 
-import com.poppo.dallab.cafeteria.domain.WorkDay;
 import com.poppo.dallab.cafeteria.domain.WorkDayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -57,16 +56,5 @@ public class DateTimeUtils {
         YearMonth yearMonth = YearMonth.of(year, month);
 
         return yearMonth.lengthOfMonth();
-    }
-
-    public boolean isThisMonthExists(Integer month) {
-        Integer thisYear = LocalDate.now().getYear();
-
-        List<WorkDay> workDays = workDayRepository.findByDateBetween(
-                LocalDate.of(thisYear, month, 1),
-                LocalDate.of(thisYear, month, this.getDayLengthOfMonth(thisYear, month))
-        );
-
-        return (workDays.size() != 0);
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/utils/DateTimeUtils.java
@@ -1,5 +1,8 @@
 package com.poppo.dallab.cafeteria.utils;
 
+import com.poppo.dallab.cafeteria.domain.WorkDay;
+import com.poppo.dallab.cafeteria.domain.WorkDayRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -14,7 +17,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 @Component
+@RequiredArgsConstructor
 public class DateTimeUtils {
+
+    private final WorkDayRepository workDayRepository;
 
     public LocalDate stringDateToLocalDate(String workDay) {
 
@@ -40,11 +46,6 @@ public class DateTimeUtils {
         Integer thisYear = LocalDate.now().getYear();
         Integer dayLength = this.getDayLengthOfMonth(thisYear, requestMonth);
 
-//        List<LocalDate> monthDays = new ArrayList<>();
-//        for (int i = 1; i < dayLength + 1; i ++) {
-//            monthDays.add(LocalDate.of(thisYear, requestMonth, i));
-//        }
-
         // range의 끝 수가 빠지는 듯
         return IntStream.range(1, dayLength + 1)
                 .mapToObj(day -> LocalDate.of(thisYear, requestMonth, day))
@@ -56,5 +57,16 @@ public class DateTimeUtils {
         YearMonth yearMonth = YearMonth.of(year, month);
 
         return yearMonth.lengthOfMonth();
+    }
+
+    public boolean isThisMonthExists(Integer month) {
+        Integer thisYear = LocalDate.now().getYear();
+
+        List<WorkDay> workDays = workDayRepository.findByDateBetween(
+                LocalDate.of(thisYear, month, 1),
+                LocalDate.of(thisYear, month, this.getDayLengthOfMonth(thisYear, month))
+        );
+
+        return (workDays.size() != 0);
     }
 }

--- a/cafeteria-manage-api/src/main/resources/application.yml
+++ b/cafeteria-manage-api/src/main/resources/application.yml
@@ -4,6 +4,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
 ---
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/CafeteriaApplicationTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/CafeteriaApplicationTests.java
@@ -3,10 +3,12 @@ package com.poppo.dallab.cafeteria;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@ActiveProfiles("test")
 public class CafeteriaApplicationTests {
 
     @Test

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/MenuPlanServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/MenuPlanServiceTests.java
@@ -1,6 +1,9 @@
 package com.poppo.dallab.cafeteria.applications;
 
-import com.poppo.dallab.cafeteria.domain.*;
+import com.poppo.dallab.cafeteria.domain.Menu;
+import com.poppo.dallab.cafeteria.domain.MenuPlan;
+import com.poppo.dallab.cafeteria.domain.MenuPlanRepository;
+import com.poppo.dallab.cafeteria.domain.WorkDay;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -8,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,6 +20,7 @@ import static org.mockito.BDDMockito.given;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@ActiveProfiles("test")
 public class MenuPlanServiceTests {
 
     MenuPlanService menuPlanService;

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -104,8 +104,8 @@ public class  WorkDayServiceTests {
     @Test
     public void workDay가_있는_달만_가져오기() {
 
-        given(dateTimeUtils.isThisMonthExists(1)).willReturn(true);
-        given(dateTimeUtils.isThisMonthExists(2)).willReturn(true);
+        given(dateTimeUtils.getDayLengthOfMonth(any(), any())).willReturn(20);
+        given(workDayRepository.storedMonthSize(any(), any())).willReturn(20);
 
         List<Integer> workMonths = workDayService.getWorkMonths();
 
@@ -113,6 +113,14 @@ public class  WorkDayServiceTests {
         assertThat(workMonths.get(1)).isEqualTo(2);
     }
 
+    @Test
+    public void 제시된_달의_저장된_workDay는_몇개인고() {
+        given(dateTimeUtils.getDayLengthOfMonth(2019, 10)).willReturn(30);
+        given(workDayRepository.storedMonthSize(any(), any())).willReturn(30);
 
+        Integer savedMonthSize = workDayService.getSavedMonthSize(10);
+
+        assertThat(savedMonthSize).isEqualTo(30);
+    }
 
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -105,7 +105,7 @@ public class  WorkDayServiceTests {
     public void workDay가_있는_달만_가져오기() {
 
         given(dateTimeUtils.getDayLengthOfMonth(any(), any())).willReturn(20);
-        given(workDayRepository.storedMonthSize(any(), any())).willReturn(20);
+        given(workDayRepository.existsByDateBetween(any(), any())).willReturn(true);
 
         List<Integer> workMonths = workDayService.getWorkMonths();
 
@@ -114,13 +114,13 @@ public class  WorkDayServiceTests {
     }
 
     @Test
-    public void 제시된_달의_저장된_workDay는_몇개인고() {
+    public void 제시된_달의_저장된_workDay가_있는고() {
         given(dateTimeUtils.getDayLengthOfMonth(2019, 10)).willReturn(30);
-        given(workDayRepository.storedMonthSize(any(), any())).willReturn(30);
+        given(workDayRepository.existsByDateBetween(any(), any())).willReturn(true);
 
-        Integer savedMonthSize = workDayService.getSavedMonthSize(10);
+        Boolean result = workDayService.isThisMonthExists(10);
 
-        assertThat(savedMonthSize).isEqualTo(30);
+        assertThat(result).isTrue();
     }
 
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.time.LocalDate;
@@ -25,7 +26,8 @@ import static org.mockito.Mockito.verify;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class WorkDayServiceTests {
+@ActiveProfiles("test")
+public class  WorkDayServiceTests {
 
     WorkDayService workDayService;
 
@@ -98,5 +100,19 @@ public class WorkDayServiceTests {
         assertThat(workDays).hasSize(30);
 
     }
+
+    @Test
+    public void workDay가_있는_달만_가져오기() {
+
+        given(dateTimeUtils.isThisMonthExists(1)).willReturn(true);
+        given(dateTimeUtils.isThisMonthExists(2)).willReturn(true);
+
+        List<Integer> workMonths = workDayService.getWorkMonths();
+
+        assertThat(workMonths.get(0)).isEqualTo(1);
+        assertThat(workMonths.get(1)).isEqualTo(2);
+    }
+
+
 
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayRepositoryTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayRepositoryTests.java
@@ -1,0 +1,37 @@
+package com.poppo.dallab.cafeteria.domain;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest
+@Transactional
+public class WorkDayRepositoryTests {
+
+    @Autowired
+    private WorkDayRepository workDayRepository;
+
+    @Test
+    public void 저장된_workDay_중_제시된_범위에_속하는_건_몇개일까() {
+        WorkDay workDay = WorkDay.builder()
+                .date(LocalDate.of(2019,10,1))
+                .build();
+        workDayRepository.save(workDay);
+
+        LocalDate startDate = LocalDate.of(2019, 10, 1);
+        LocalDate endDate = LocalDate.of(2019, 10, 30);
+
+        Integer monthSize = workDayRepository.storedMonthSize(startDate, endDate);
+
+        assertThat(monthSize).isEqualTo(1);
+    }
+
+}

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayRepositoryTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/domain/WorkDayRepositoryTests.java
@@ -20,7 +20,8 @@ public class WorkDayRepositoryTests {
     private WorkDayRepository workDayRepository;
 
     @Test
-    public void 저장된_workDay_중_제시된_범위에_속하는_건_몇개일까() {
+    public void 저장된_workDay_중_제시된_범위에_속하는_게_있는가() {
+
         WorkDay workDay = WorkDay.builder()
                 .date(LocalDate.of(2019,10,1))
                 .build();
@@ -29,9 +30,9 @@ public class WorkDayRepositoryTests {
         LocalDate startDate = LocalDate.of(2019, 10, 1);
         LocalDate endDate = LocalDate.of(2019, 10, 30);
 
-        Integer monthSize = workDayRepository.storedMonthSize(startDate, endDate);
+        Boolean result = workDayRepository.existsByDateBetween(startDate, endDate);
 
-        assertThat(monthSize).isEqualTo(1);
+        assertThat(result).isTrue();
     }
 
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/WorkDayControllerTests.java
@@ -11,12 +11,14 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -30,6 +32,22 @@ public class WorkDayControllerTests {
 
     @MockBean
     private WorkDayService workDayService;
+
+    @Test
+    public void 일하는_날이_있는_월만_목록으로_가져오기() throws  Exception {
+
+        List<Integer> mockWorkMonthList = Arrays.asList(10);
+
+        given(workDayService.getWorkMonths()).willReturn(mockWorkMonthList);
+
+        mvc.perform(get("/workMonth"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("existedMonthList")))
+                .andExpect(content().string(containsString("[")))
+                .andExpect(content().string(containsString("10")))
+        ;
+
+    }
 
     @Test
     public void 새로운_달의_시작_요청() throws Exception {

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
@@ -1,22 +1,34 @@
 package com.poppo.dallab.cafeteria.utils;
 
+import com.poppo.dallab.cafeteria.domain.WorkDay;
+import com.poppo.dallab.cafeteria.domain.WorkDayRepository;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 public class DateTimeUtilsTests {
 
     @Autowired
     private DateTimeUtils dateTimeUtils;
 
+    @Mock
+    private WorkDayRepository workDayRepository;
+
     @Before
     public void setup() {
-        dateTimeUtils = new DateTimeUtils();
+        MockitoAnnotations.initMocks(this);
+
+        dateTimeUtils = new DateTimeUtils(workDayRepository);
     }
 
     @Test
@@ -90,6 +102,17 @@ public class DateTimeUtilsTests {
         Integer monthDaySize = dateTimeUtils.getDayLengthOfMonth(2016, 2);
 
         assertThat(monthDaySize).isEqualTo(29);
+    }
+
+    @Test
+    public void 이_달은_존재하나() {
+        List<WorkDay> mockWorkDays = Arrays.asList(WorkDay.builder().build());
+
+        given(workDayRepository.findByDateBetween(any(), any())).willReturn(mockWorkDays);
+
+        boolean thisMonthExists = dateTimeUtils.isThisMonthExists(10);
+
+        assertThat(thisMonthExists).isTrue();
     }
 
 }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/utils/DateTimeUtilsTests.java
@@ -1,6 +1,5 @@
 package com.poppo.dallab.cafeteria.utils;
 
-import com.poppo.dallab.cafeteria.domain.WorkDay;
 import com.poppo.dallab.cafeteria.domain.WorkDayRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,12 +8,9 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 public class DateTimeUtilsTests {
 
@@ -102,17 +98,6 @@ public class DateTimeUtilsTests {
         Integer monthDaySize = dateTimeUtils.getDayLengthOfMonth(2016, 2);
 
         assertThat(monthDaySize).isEqualTo(29);
-    }
-
-    @Test
-    public void 이_달은_존재하나() {
-        List<WorkDay> mockWorkDays = Arrays.asList(WorkDay.builder().build());
-
-        given(workDayRepository.findByDateBetween(any(), any())).willReturn(mockWorkDays);
-
-        boolean thisMonthExists = dateTimeUtils.isThisMonthExists(10);
-
-        assertThat(thisMonthExists).isTrue();
     }
 
 }

--- a/cafeteria-manage-web/src/api/index.js
+++ b/cafeteria-manage-web/src/api/index.js
@@ -29,5 +29,8 @@ export const menu = {
 export const menuPlan = {
   create(menuPlanMonth) {
     return request('post', '/workDay', { menuPlanMonth })
+  },
+  fetchMonth()  {
+    return request('get', '/workMonth')
   }
 }

--- a/cafeteria-manage-web/src/components/AddMenuplan.vue
+++ b/cafeteria-manage-web/src/components/AddMenuplan.vue
@@ -10,7 +10,7 @@
         <div slot="body">
             <form id="update-menu-form" 
                 @submit="addMenuplan">
-                <input class="form-control" type="text" v-model="input" name="menuName" ref="input">
+                <input class="form-control" type="text" v-model="input" name="workMonth" ref="input">
             </form>
         </div>
         <div slot="footer">

--- a/cafeteria-manage-web/src/components/MenuHome.vue
+++ b/cafeteria-manage-web/src/components/MenuHome.vue
@@ -3,7 +3,7 @@
         <div class="menu-home-title">메뉴 관리</div>
         <div class="menu-list">
             <div class="menu-item" v-for="menu in menus" :key="menu.id"
-                ref="boardItem">
+                ref="menuItem">
                 <router-link :to="`/menus/${menu.id}`">
                     <div class="menu-item-title">{{ menu.menuName }}</div>
                 </router-link>

--- a/cafeteria-manage-web/src/components/MenuplanHome.vue
+++ b/cafeteria-manage-web/src/components/MenuplanHome.vue
@@ -2,18 +2,24 @@
     <div>
         <div class="menu-plan-home-title">식단 관리</div>
         <div class="menu-plan-list">
-            <div class="menu-plan-item menu-plan-item-new">
-                <a class="new-menu-plan-btn" href="" @click.prevent="SET_IS_ADD_MENUPLAN(true)">
-                    &plus; 새 식단 추가
-                </a>
-            </div>
+          <div class="menu-plan-item" v-for="month in menuPlanMonth" :key="month"
+              ref="menuPlanItem">
+              <a>
+                  <div class="menu-plan-item-title">{{ month }}월</div>
+              </a>
+          </div>
+          <div class="menu-plan-item menu-plan-item-new">
+              <a class="new-menu-plan-btn" href="" @click.prevent="SET_IS_ADD_MENUPLAN(true)">
+                  &plus; 새 식단 추가
+              </a>
+          </div>
         </div>
         <AddMenuplan v-if="isAddMenuplan" />
     </div>
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex'
+import { mapState, mapMutations, mapActions } from 'vuex'
 import AddMenuplan from './AddMenuplan.vue'
 
 export default {
@@ -22,18 +28,31 @@ export default {
     },
     data() {
         return {
-
+          loading: false,
         }
     },
     computed: {
         ...mapState({
-            isAddMenuplan: 'isAddMenuplan'
+            isAddMenuplan: 'isAddMenuplan',
+            menuPlanMonth: 'menuPlanMonth',
         })
+    },
+    created() {
+      this.fetchData()
     },
     methods: {
         ...mapMutations([
             'SET_IS_ADD_MENUPLAN'
-        ])
+        ]),
+        ...mapActions([
+          'GET_MENUPLANMONTH'
+        ]),
+        fetchData() {
+            this.loading = true
+            this.GET_MENUPLANMONTH().finally(_ => {
+                this.loading = false
+            })
+        }
     }
 }
 </script>
@@ -79,5 +98,11 @@ export default {
   width: inherit;
   color: #888;
   font-weight: 700;
+}
+.menu-plan-item-title {
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+  padding: 10px;
 }
 </style>

--- a/cafeteria-manage-web/src/store/actions.js
+++ b/cafeteria-manage-web/src/store/actions.js
@@ -26,9 +26,15 @@ const actions = {
     },
 
     // Menuplan actions
-    ADD_MENUPLAN(_, { menuPlanMonth }) {
+    ADD_MENUPLAN({ dispatch }, { menuPlanMonth }) {
         return api.menuPlan.create(menuPlanMonth).then(data => {
+            dispatch('GET_MENUPLANMONTH')
             return data
+        })
+    },
+    GET_MENUPLANMONTH({ commit }) {
+        return api.menuPlan.fetchMonth().then(data => {
+            commit('SET_MENUPLANMONTH', data.existedMonthList)
         })
     }
 }

--- a/cafeteria-manage-web/src/store/mutations.js
+++ b/cafeteria-manage-web/src/store/mutations.js
@@ -14,6 +14,9 @@ const mutations = {
     
     SET_IS_ADD_MENUPLAN(state, toggle) {
         state.isAddMenuplan = toggle
+    },
+    SET_MENUPLANMONTH(state, menuPlanMonth) {
+        state.menuPlanMonth = menuPlanMonth
     }
 }
 

--- a/cafeteria-manage-web/src/store/state.js
+++ b/cafeteria-manage-web/src/store/state.js
@@ -4,6 +4,7 @@ const state = {
     isAddMenuplan: false,
     menus: [],
     menu: {},
+    menuPlanMonth: [],
 }
 
 export default state

--- a/httpTest/WorkDayTest.http
+++ b/httpTest/WorkDayTest.http
@@ -6,3 +6,16 @@ Content-Type: application/json
 }
 
 ###
+
+POST http://localhost:8080/workDay
+Content-Type: application/json
+
+{
+  "menuPlanMonth": 2
+}
+
+###
+
+GET http://localhost:8080/workMonth
+
+###


### PR DESCRIPTION
1. GET /workMonth API 구현
- DB에 저장된 WorkDay들을 확인하고 날짜가 한개라도 있는 달을 반환해줌
- 각 월마다 존재하는지 stream을 통해 12달 모두 확인
- datetimeutil에서 workdayRepository 의존성을 갖는게 좋은 선택인지 잘 모르겠음
- 한방에 쿼리가 너무 매번 12개씩 나가는 건 아닌지 걱정됨

2. 식단 관리 메인페이지 구현
- 식단 생성이 가능한 월의 리스트 보임
- 식단 생성 월 추가 시 리스트 데이터 변경

3. isThisMonthExists 함수 수정
- 기존 DateTimeUtil 내의 isThisMonthExists 삭제
- WorkDayRepository 쪽의 새로운 쿼리 작성(storedMonthSize)
- WorkDayService에서 새로운 쿼리를 통해 저장된 WorkDay 중 존재하는 월만 골라내도록 책임 이관

4. workDay에서 월단위 탐색 방법 수정
- 갯수를 찾는 방식에서 존재 여부를 따지는 방식으로 변경(find+count -> exists)
- 관련 테스트 및 서비스 수정