### PR TITLE
Modify fetch menu plan

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
@@ -9,8 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -29,10 +27,5 @@ public class MenuPlanService {
                 .build();
 
         return menuPlanRepository.save(menuPlan);
-    }
-
-    public List<Menu> getMenuByWorkDayId(Long workDayId) {
-
-        return null;
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/MenuPlanService.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -27,5 +29,10 @@ public class MenuPlanService {
                 .build();
 
         return menuPlanRepository.save(menuPlan);
+    }
+
+    public List<Menu> getMenuByWorkDayId(Long workDayId) {
+
+        return null;
     }
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanResponseDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuPlanResponseDto.java
@@ -1,6 +1,5 @@
 package com.poppo.dallab.cafeteria.dto;
 
-import com.poppo.dallab.cafeteria.domain.Menu;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +20,6 @@ public class MenuPlanResponseDto {
 
     LocalDate date;
 
-    List<Menu> menus;
+    List<MenuResponseDto> menus;
 
 }

--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuResponseDto.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/dto/MenuResponseDto.java
@@ -1,10 +1,14 @@
 package com.poppo.dallab.cafeteria.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class MenuResponseDto {
 
     private Long id;

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
@@ -64,7 +64,7 @@ public class MenuPlanControllerTests {
                 .andExpect(content().string(containsString("2019-11-01")))
                 .andExpect(content().string(containsString("\"workDayId\":1")))
                 .andExpect(content().string(containsString("\"menus\":[")))
-                .andExpect(content().string(containsString("")))
+                .andExpect(content().string(containsString("밥")))
             ;
     }
 

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/interfaces/MenuPlanControllerTests.java
@@ -1,6 +1,5 @@
 package com.poppo.dallab.cafeteria.interfaces;
 
-import com.poppo.dallab.cafeteria.adapters.Mapper;
 import com.poppo.dallab.cafeteria.applications.MenuPlanService;
 import com.poppo.dallab.cafeteria.applications.MenuService;
 import com.poppo.dallab.cafeteria.applications.WorkDayService;
@@ -44,9 +43,6 @@ public class MenuPlanControllerTests {
     @MockBean
     MenuService menuService;
 
-    @MockBean
-    Mapper mapper;
-
     @Test
     public void getListByMonth() throws Exception {
 
@@ -55,13 +51,20 @@ public class MenuPlanControllerTests {
                 .date(LocalDate.of(2019,11,1))
                 .build());
 
+        List<Menu> menus = Arrays.asList(Menu.builder()
+                .name("밥")
+                .build());
+
         given(workDayService.getWorkDaysByMonth(2019, 11)).willReturn(workDays);
+        given(menuService.getMenusByWorkDayId(1L)).willReturn(menus);
 
         mvc.perform(get("/menuPlans?year=2019&month=11"))
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("[")))
                 .andExpect(content().string(containsString("2019-11-01")))
                 .andExpect(content().string(containsString("\"workDayId\":1")))
+                .andExpect(content().string(containsString("\"menus\":[")))
+                .andExpect(content().string(containsString("")))
             ;
     }
 

--- a/httpTest/AddMenuPlanTest.http
+++ b/httpTest/AddMenuPlanTest.http
@@ -15,3 +15,12 @@ Content-Type: application/json
 }
 
 ###
+
+POST http://localhost:8080/workDays/1/menu
+Content-Type: application/json
+
+{
+  "menuName": "오징어볶음"
+}
+
+###

--- a/httpTest/GetMenuPlanTest.http
+++ b/httpTest/GetMenuPlanTest.http
@@ -1,3 +1,3 @@
-GET http://localhost:8080/menuPlans?year=2019&month=10
+GET http://localhost:8080/menuPlans?year=2019&month=11
 
 ###


### PR DESCRIPTION
1. 월별 식단 조회 API 기능 추가
- 해당 일자의 메뉴 목록을 갖고와서 DTO로 변환 후 클라이언트에게 전달
2. 사용하지 않는 코드 제거
3.  MenuPlanController 테스트 케이스 수정