### PR TITLE
Menuplan pagination front

### DIFF
--- a/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
+++ b/cafeteria-manage-api/src/main/java/com/poppo/dallab/cafeteria/applications/WorkDayService.java
@@ -105,7 +105,10 @@ public class WorkDayService {
         // 무조건 2주차부터 오기 때문에 숫자 계산이 이상해짐
         LocalDate startDate = mondaysOfMonth.get(weekCount - 2);
 
-        List<WorkDay> workDays = workDayRepository.findByDateBetween(startDate, startDate.plusDays(4L));
+        List<WorkDay> workDays = workDayRepository.findByDateBetween(startDate, startDate.plusDays(4L)).stream()
+                .filter(workDay -> workDay.getDate().getMonthValue() == month)
+                .collect(Collectors.toList())
+        ;
 
         return workDays;
     }

--- a/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
+++ b/cafeteria-manage-api/src/test/java/com/poppo/dallab/cafeteria/applications/WorkDayServiceTests.java
@@ -161,7 +161,8 @@ public class  WorkDayServiceTests {
     @Test
     public void 해당월의_첫번째주를_제외한_주의_workDay_가져오기() {
 
-        List<WorkDay> workDays = Arrays.asList(WorkDay.builder().id(1L).build());
+        List<WorkDay> workDays = Arrays.asList(
+                WorkDay.builder().date(LocalDate.of(2019,11,1)).id(1L).build());
 
         given(dateTimeUtils.getMondaysOfMonthExceptFirstWeek(2019,11)).willReturn(
                 Arrays.asList(

--- a/cafeteria-manage-web/src/api/index.js
+++ b/cafeteria-manage-web/src/api/index.js
@@ -33,13 +33,13 @@ export const menuPlan = {
   fetchMonth()  {
     return request('get', '/workMonth')
   },
-  fetchMonthlyMenuPlan(year, month) {
-    return request('get', `/menuPlans?year=${ year }&month=${ month }&weekCount=1`)
+  fetchMonthlyMenuPlan(year, month, weekCount) {
+    return request('get', `/menuPlans?year=${year}&month=${month}&weekCount=${weekCount}`)
   },
   ceateMenuPlan(workDayId, menuName) {
-    return request('post', `/workDays/${ workDayId }/menu`, { menuName })
+    return request('post', `/workDays/${workDayId}/menu`, {menuName})
   },
   deleteMenuPlan(workDayId, menuId) {
-    return request('delete', `/workDays/${ workDayId }/menu/${ menuId }`)
+    return request('delete', `/workDays/${workDayId}/menu/${menuId}`)
   }
 }

--- a/cafeteria-manage-web/src/components/AddMenuOnMenuplan.vue
+++ b/cafeteria-manage-web/src/components/AddMenuOnMenuplan.vue
@@ -16,7 +16,7 @@ export default {
     data() {
         return {
             menuName: "",
-            month: this.$route.params.month
+            month: this.$route.params.month,
         }
     },
     computed: {
@@ -27,7 +27,7 @@ export default {
           year: 'year'
         })
     },
-    props: ['workDayId'],
+    props: ['workDayId', 'weekCount'],
     methods: {
       ...mapActions([
         'ADD_MENUTOMENUPLAN'
@@ -37,7 +37,8 @@ export default {
           workDayId: this.workDayId,
           menuName: this.menuName,
           year: this.year,
-          month: this.month
+          month: this.month,
+          weekCount: this.weekCount,
         })
           .catch(err => alert(err.data))
           .finally(_ => this.menuName = "")

--- a/cafeteria-manage-web/src/components/MenuItem.vue
+++ b/cafeteria-manage-web/src/components/MenuItem.vue
@@ -21,7 +21,7 @@ export default {
       year: 'year'
     })
   },
-  props: ['data', 'workDayId'],
+  props: ['data', 'workDayId', 'weekCount'],
   methods: {
     ...mapActions([
       'DELETE_MENUPLAN'
@@ -35,7 +35,8 @@ export default {
         workDayId: this.workDayId,
         menuId: this.data.id,
         year: this.year,
-        month: this.month
+        month: this.month,
+        weekCount: this.weekCount
       })
     } 
   }

--- a/cafeteria-manage-web/src/components/MenuplanList.vue
+++ b/cafeteria-manage-web/src/components/MenuplanList.vue
@@ -2,10 +2,10 @@
     <div class="menuplan" :data-monthlyMenuPlan-id="data.workDayId">
         <div class="menuplan-header">
           <div class="menuplan-header-title">{{ data.date }} {{ data.day }}</div>
-          <a class="delete-menu-list-btn" href="" @click.prevent="onDeleteList">&times;</a>
+          <a class="delete-menu-list2-btn" href="" @click.prevent="onDeleteList">&times;</a>
         </div>
 
-        <div class="menu-list" :data-monthlyMenuPlan-id="data.workDayId">
+        <div class="menu-list2" :data-monthlyMenuPlan-id="data.workDayId">
           <MenuItem v-for="menu in data.menus" :key="`${ menu.id }`" :data="menu" :work-day-id="data.workDayId" />
         </div>
 
@@ -67,12 +67,12 @@ export default {
   padding-left: 8px;
   line-height: 30px;
 }
-.menu-list {
+.menu-list2 {
   flex: 1 1 auto;
   overflow-y: scroll;
   min-height: 10px;
 }
-.delete-menu-list-btn {
+.delete-menu-list2-btn {
   position: absolute;
   right: 10px;
   top: 8px;

--- a/cafeteria-manage-web/src/components/MenuplanList.vue
+++ b/cafeteria-manage-web/src/components/MenuplanList.vue
@@ -6,11 +6,11 @@
         </div>
 
         <div class="menu-list2" :data-monthlyMenuPlan-id="data.workDayId">
-          <MenuItem v-for="menu in data.menus" :key="`${ menu.id }`" :data="menu" :work-day-id="data.workDayId" />
+          <MenuItem v-for="menu in data.menus" :key="`${ menu.id }`" :data="menu" :work-day-id="data.workDayId" :week-count="weekCount"/>
         </div>
 
         <div v-if="isAddMenu">
-          <AddMenuOnMenuplan :work-day-id="data.workDayId" @close="isAddMenu=false"/>
+          <AddMenuOnMenuplan :work-day-id="data.workDayId" :week-count="weekCount" @close="isAddMenu=false"/>
         </div>
         <div v-else>
           <a class="add-menu-btn" href="" @click.prevent="isAddMenu=true">
@@ -30,7 +30,7 @@ export default {
         isAddMenu: false
       }
     },
-    props: ['data'],
+    props: ['data', 'weekCount'],
     components: {
       MenuItem,
       AddMenuOnMenuplan,

--- a/cafeteria-manage-web/src/components/MonthlyMenuplan.vue
+++ b/cafeteria-manage-web/src/components/MonthlyMenuplan.vue
@@ -3,7 +3,14 @@
         <div class="board">
 
             <div class="board-header">
-                <span class="board-title">{{ month }}월</span>
+                <span class="board-title">
+                    {{ month }}월
+                    <div class="week-count">
+                        <a class="arrow-button" href="" @click.prevent="onPrevWeek">&#8249;</a>
+                        {{ weekCount }}주차
+                        <a class="arrow-button" href="" @click.prevent="onNextWeek">&#8250;</a>
+                    </div>
+                </span>
             </div>
 
             <div class="menuplan-list-section-wrapper">
@@ -30,7 +37,8 @@ export default {
     data() {
         return {
             loading: false,
-            month: this.$route.params.month
+            month: this.$route.params.month,
+            weekCount: 1,
         }
     },
     created() {
@@ -48,9 +56,20 @@ export default {
         ]),
         fetchData() {
             this.loading = true
-            this.GET_MONTHLYMENUPLANS({ year: this.year, month: this.month }).finally(_ => {
+            this.GET_MONTHLYMENUPLANS({ year: this.year, month: this.month, weekCount: this.weekCount }).finally(_ => {
                 this.loading = false
             })
+        },
+        onNextWeek() {
+            // TODO: 현재 월의 최대 주차 넘어가면 숫자 증가 못하는 기능 추가
+            this.weekCount += 1;
+            this.fetchData();
+        },
+        onPrevWeek() {
+            if (this.weekCount > 1) {
+                this.weekCount -= 1;
+                this.fetchData();
+            }
         }
     }
 }
@@ -79,6 +98,8 @@ export default {
 .board-title {
   font-weight: 700;
   font-size: 18px;
+  display: flex;
+  padding: 0px 10px;
 }
 .menuplan-list-section-wrapper {
   flex-grow: 1;
@@ -104,5 +125,15 @@ export default {
   vertical-align: top;
   padding: 5px;
   margin-right: 5px;
+}
+.arrow-button {
+  background-color: rgb(0, 121, 191);
+  color: #fff;
+  border-radius: 50%;
+  padding: 4px 8px;
+  text-decoration: none
+}
+.week-count {
+  padding: 0px 32px;
 }
 </style>

--- a/cafeteria-manage-web/src/components/MonthlyMenuplan.vue
+++ b/cafeteria-manage-web/src/components/MonthlyMenuplan.vue
@@ -4,7 +4,9 @@
 
             <div class="board-header">
                 <span class="board-title">
-                    {{ month }}월
+                    <div class="title-month">
+                        {{ month }}월
+                    </div>
                     <div class="week-count">
                         <a class="arrow-button" href="" @click.prevent="onPrevWeek">&#8249;</a>
                         {{ weekCount }}주차
@@ -17,7 +19,7 @@
                 <div class="menuplan-list-section">
                     <div class="menuplan-list-wrapper" v-for="monthlyMenuPlan in monthlyMenuPlans"
                         :key="monthlyMenuPlan.workDayId" :data-monthlyMenuPlan-id="monthlyMenuPlan.workDayId">
-                        <MenuplanList :data="monthlyMenuPlan" />
+                        <MenuplanList :data="monthlyMenuPlan" :week-count="weekCount"/>
                     </div>
                 </div>
             </div>
@@ -135,5 +137,8 @@ export default {
 }
 .week-count {
   padding: 0px 32px;
+}
+.title-month {
+  font-size: x-large
 }
 </style>

--- a/cafeteria-manage-web/src/store/actions.js
+++ b/cafeteria-manage-web/src/store/actions.js
@@ -37,8 +37,8 @@ const actions = {
             commit('SET_MENUPLANMONTH', data.existedMonthList)
         })
     },
-    GET_MONTHLYMENUPLANS({ commit }, { year, month }) {
-        return api.menuPlan.fetchMonthlyMenuPlan(year, month).then(data => {
+    GET_MONTHLYMENUPLANS({ commit }, { year, month, weekCount }) {
+        return api.menuPlan.fetchMonthlyMenuPlan(year, month, weekCount).then(data => {
             commit('SET_MONTHLYMENUPLANS', data)
         })
     },

--- a/cafeteria-manage-web/src/store/actions.js
+++ b/cafeteria-manage-web/src/store/actions.js
@@ -42,14 +42,14 @@ const actions = {
             commit('SET_MONTHLYMENUPLANS', data)
         })
     },
-    ADD_MENUTOMENUPLAN({ dispatch }, { workDayId, menuName, year, month }) {
+    ADD_MENUTOMENUPLAN({ dispatch }, { workDayId, menuName, year, month, weekCount }) {
         return api.menuPlan.ceateMenuPlan(workDayId, menuName).then(_ => {
-            dispatch('GET_MONTHLYMENUPLANS', { year, month })
+            dispatch('GET_MONTHLYMENUPLANS', { year, month, weekCount })
         })
     },
-    DELETE_MENUPLAN({ dispatch }, { workDayId, menuId, year, month }) {
+    DELETE_MENUPLAN({ dispatch }, { workDayId, menuId, year, month, weekCount }) {
         return api.menuPlan.deleteMenuPlan(workDayId, menuId).then(_ => {
-            dispatch('GET_MONTHLYMENUPLANS', { year, month })
+            dispatch('GET_MONTHLYMENUPLANS', { year, month, weekCount })
         })
     }
 }


### PR DESCRIPTION
1. 월간 메뉴 조회 이전주, 다음주 넘기기 버튼 추가
- 각 월별 식단 관리에서 주별 관리를 위해 주 넘기는 버튼 구현

2. 프론트엔드 -> 백엔드 요청 수정
- weekcount 추가 이후 메뉴 추가 및 삭제 시 fetch 방식이 바뀜
- 바뀐 방식에 따라 MenuPlanHome 컴포넌트에서 weekCount를 props로 전달하도록 변경

3. 주별 식단 조회 시 해당 월을 벗어나는 경우 수정
- 마지막 주의 경우 요청된 월을 넘어서는 경우가 존재 (ex. 12월31일(수) 1월1일(목))
- 이를 방지하기 위해 백엔드에서 데이터 전송 시 요청된 월과 같은 날만을 필터링해서 전달 