### PR TITLE
2020년 대응 변경

### DIFF
--- a/cafeteria-manage-web/src/components/Navbar.vue
+++ b/cafeteria-manage-web/src/components/Navbar.vue
@@ -6,14 +6,14 @@
         <ul class="header-menus">
             <li class="header-menu"><router-link to="/menus">메뉴 관리</router-link></li>
             <li class="header-menu"><router-link to="/menuplans">식단 관리</router-link></li>
-            <li class="header-menu"><router-link to="/ingredients">식자재 관리</router-link></li>
+            <!-- <li class="header-menu"><router-link to="/ingredients">식자재 관리</router-link></li> -->
         </ul>
     </nav>
 </template>
 
 <script>
 export default {
-    
+
 }
 </script>
 

--- a/cafeteria-manage-web/src/store/state.js
+++ b/cafeteria-manage-web/src/store/state.js
@@ -1,5 +1,5 @@
 const state = {
-    year: 2019,
+    year: 2020,
     isAddMenu: false,
     isMenu: false,
     isAddMenuplan: false,

--- a/httpTest/GetMenuPlanTest.http
+++ b/httpTest/GetMenuPlanTest.http
@@ -1,95 +1,95 @@
-GET http://localhost:8080/menuPlans?year=2019&month=1&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=1&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=1&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=1&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=2&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=2&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=2&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=2&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=3&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=3&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=3&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=3&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=4&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=4&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=4&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=4&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=5&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=5&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=5&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=5&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=6&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=6&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=6&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=6&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=7&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=7&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=7&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=7&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=8&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=8&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=8&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=8&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=9&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=9&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=9&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=9&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=10&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=10&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=10&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=10&weekCount=2
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=11&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=11&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=11&weekCount=5
+GET http://localhost:8080/menuPlans?year=2020&month=11&weekCount=5
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=12&weekCount=1
+GET http://localhost:8080/menuPlans?year=2020&month=12&weekCount=1
 
 ###
 
-GET http://localhost:8080/menuPlans?year=2019&month=12&weekCount=2
+GET http://localhost:8080/menuPlans?year=2020&month=12&weekCount=2
 
 ###

--- a/httpTest/WorkDayTest.http
+++ b/httpTest/WorkDayTest.http
@@ -2,7 +2,7 @@ POST http://localhost:8080/workDay
 Content-Type: application/json
 
 {
-  "menuPlanMonth": 11
+  "menuPlanMonth": 1
 }
 
 ###


### PR DESCRIPTION
- 프론트엔드 상태 관리 2020년으로 변경
    - 모든 년도에 대응하도록 향후 수정 필요
- 테스트 케이스 2020년도로 변경
- 향후 구현 예정 기능 Navbar에서 제거